### PR TITLE
fix: retry transient SNS/notification errors for concurrent topics

### DIFF
--- a/provider/resource_radosgw_s3_bucket_notification.go
+++ b/provider/resource_radosgw_s3_bucket_notification.go
@@ -180,10 +180,15 @@ func (r *S3BucketNotificationResource) Create(ctx context.Context, req resource.
 		return
 	}
 
-	// Put the notification configuration on the bucket
-	_, err := r.client.S3.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
-		Bucket:                    aws.String(bucket),
-		NotificationConfiguration: notifConfig,
+	// Put the notification configuration on the bucket. Retry transient errors:
+	// under concurrent topic churn RadosGW can briefly fail to resolve a
+	// referenced topic and return NoSuchKey/5xx even though the topic exists.
+	err := retryOnTransientSNSError(ctx, fmt.Sprintf("PutBucketNotificationConfiguration %s", bucket), func() error {
+		_, putErr := r.client.S3.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
+			Bucket:                    aws.String(bucket),
+			NotificationConfiguration: notifConfig,
+		})
+		return putErr
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -290,10 +295,13 @@ func (r *S3BucketNotificationResource) Update(ctx context.Context, req resource.
 	}
 
 	// Clear existing notifications first — RadosGW merges rather than replaces
-	// topic configurations when the topic ARN changes.
-	_, err := r.client.S3.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
-		Bucket:                    aws.String(bucket),
-		NotificationConfiguration: &s3types.NotificationConfiguration{},
+	// topic configurations when the topic ARN changes. Retry transient errors.
+	err := retryOnTransientSNSError(ctx, fmt.Sprintf("PutBucketNotificationConfiguration(clear) %s", bucket), func() error {
+		_, putErr := r.client.S3.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
+			Bucket:                    aws.String(bucket),
+			NotificationConfiguration: &s3types.NotificationConfiguration{},
+		})
+		return putErr
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -303,10 +311,15 @@ func (r *S3BucketNotificationResource) Update(ctx context.Context, req resource.
 		return
 	}
 
-	// Put the new notification configuration
-	_, err = r.client.S3.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
-		Bucket:                    aws.String(bucket),
-		NotificationConfiguration: notifConfig,
+	// Put the new notification configuration. Retry transient errors: under
+	// concurrent topic churn RadosGW can briefly fail to resolve a referenced
+	// topic and return NoSuchKey/5xx even though the topic exists.
+	err = retryOnTransientSNSError(ctx, fmt.Sprintf("PutBucketNotificationConfiguration %s", bucket), func() error {
+		_, putErr := r.client.S3.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
+			Bucket:                    aws.String(bucket),
+			NotificationConfiguration: notifConfig,
+		})
+		return putErr
 	})
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -353,10 +366,14 @@ func (r *S3BucketNotificationResource) Delete(ctx context.Context, req resource.
 
 	bucket := state.Bucket.ValueString()
 
-	// Delete by putting an empty notification configuration
-	_, err := r.client.S3.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
-		Bucket:                    aws.String(bucket),
-		NotificationConfiguration: &s3types.NotificationConfiguration{},
+	// Delete by putting an empty notification configuration. Retry transient
+	// errors; a permanent NoSuchBucket is not retried and is handled below.
+	err := retryOnTransientSNSError(ctx, fmt.Sprintf("PutBucketNotificationConfiguration(delete) %s", bucket), func() error {
+		_, putErr := r.client.S3.PutBucketNotificationConfiguration(ctx, &s3.PutBucketNotificationConfigurationInput{
+			Bucket:                    aws.String(bucket),
+			NotificationConfiguration: &s3types.NotificationConfiguration{},
+		})
+		return putErr
 	})
 	if err != nil {
 		var apiErr smithy.APIError

--- a/provider/resource_radosgw_sns_topic.go
+++ b/provider/resource_radosgw_sns_topic.go
@@ -330,7 +330,14 @@ func (r *SNSTopicResource) Create(ctx context.Context, req resource.CreateReques
 	params.Set("Action", "CreateTopic")
 	params.Set("Name", plan.Name.ValueString())
 
-	body, err := r.iamClient.DoPostRequest(ctx, params, "sns")
+	// Retry transient errors (5xx / ConcurrentModification) from concurrent topic
+	// churn on RadosGW's shared per-owner topic metadata.
+	var body []byte
+	err := retryOnTransientSNSError(ctx, fmt.Sprintf("CreateTopic %s", plan.Name.ValueString()), func() error {
+		var reqErr error
+		body, reqErr = r.iamClient.DoPostRequest(ctx, params, "sns")
+		return reqErr
+	})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Creating SNS Topic",
@@ -564,7 +571,10 @@ func (r *SNSTopicResource) Delete(ctx context.Context, req resource.DeleteReques
 	params.Set("Action", "DeleteTopic")
 	params.Set("TopicArn", state.ARN.ValueString())
 
-	_, err := r.iamClient.DoPostRequest(ctx, params, "sns")
+	err := retryOnTransientSNSError(ctx, fmt.Sprintf("DeleteTopic %s", state.ARN.ValueString()), func() error {
+		_, delErr := r.iamClient.DoPostRequest(ctx, params, "sns")
+		return delErr
+	})
 	if err != nil {
 		// Deleting an already-deleted topic is not considered an error by RadosGW
 		if isSNSTopicNotFound(err) {

--- a/provider/resource_radosgw_sns_topic_test.go
+++ b/provider/resource_radosgw_sns_topic_test.go
@@ -4,10 +4,15 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
+
+// snsCheckRetryTimeout bounds retries in the SNS test check helpers, absorbing
+// the same shared-metadata eventual consistency the resources retry on.
+const snsCheckRetryTimeout = 30 * time.Second
 
 func TestAccRadosgwSNSTopic_basic(t *testing.T) {
 	t.Parallel()
@@ -195,12 +200,19 @@ func testAccCheckRadosgwSNSTopicExists(resourceName string) resource.TestCheckFu
 		params.Set("Action", "GetTopicAttributes")
 		params.Set("TopicArn", arn)
 
-		_, err := iamClient.DoRequest(testCtx, params, "sns")
-		if err != nil {
-			return fmt.Errorf("error verifying SNS topic %s exists: %s", arn, err)
+		// Retry to absorb transient inconsistency under concurrent topic churn.
+		deadline := time.Now().Add(snsCheckRetryTimeout)
+		var lastErr error
+		for {
+			_, lastErr = iamClient.DoRequest(testCtx, params, "sns")
+			if lastErr == nil {
+				return nil
+			}
+			if time.Now().After(deadline) {
+				return fmt.Errorf("error verifying SNS topic %s exists: %s", arn, lastErr)
+			}
+			time.Sleep(time.Second)
 		}
-
-		return nil
 	}
 }
 
@@ -230,13 +242,22 @@ func testAccCheckRadosgwSNSTopicDestroy(s *terraform.State) error {
 		params.Set("Action", "GetTopicAttributes")
 		params.Set("TopicArn", arn)
 
-		_, err := iamClient.DoRequest(testCtx, params, "sns")
-		if err == nil {
-			return fmt.Errorf("SNS topic %s still exists after destroy", arn)
-		}
-
-		if !isSNSTopicNotFound(err) {
-			return fmt.Errorf("unexpected error checking topic %s after destroy: %s", arn, err)
+		// Retry until the topic is reported gone. Under concurrent topic churn the
+		// topic can remain briefly visible after delete, or the check itself can
+		// hit a transient error; only fail if the condition persists.
+		deadline := time.Now().Add(snsCheckRetryTimeout)
+		for {
+			_, err := iamClient.DoRequest(testCtx, params, "sns")
+			if isSNSTopicNotFound(err) {
+				break
+			}
+			if time.Now().After(deadline) {
+				if err == nil {
+					return fmt.Errorf("SNS topic %s still exists after destroy", arn)
+				}
+				return fmt.Errorf("unexpected error checking topic %s after destroy: %s", arn, err)
+			}
+			time.Sleep(time.Second)
 		}
 	}
 	return nil

--- a/provider/utils.go
+++ b/provider/utils.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"github.com/aws/smithy-go"
 	"github.com/ceph/go-ceph/rgw/admin"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -84,6 +85,69 @@ func retryOnNotFound(ctx context.Context, operation string, isNotFound func(erro
 		}
 		if isNotFound(err) {
 			tflog.Debug(ctx, "Resource not yet visible, retrying", map[string]any{
+				"operation": operation,
+				"error":     err.Error(),
+			})
+			return retry.RetryableError(err)
+		}
+		return retry.NonRetryableError(err)
+	})
+}
+
+// SNSTransientRetryTimeout bounds retries of transient SNS/notification errors.
+// Contention on RadosGW's shared per-owner topic metadata resolves in well under
+// a second, so a short window absorbs it while a genuinely persistent error
+// (e.g. a real missing bucket) still surfaces quickly.
+const SNSTransientRetryTimeout = 30 * time.Second
+
+// isTransientSNSError reports whether err from an SNS topic or bucket-notification
+// operation is transient and worth retrying. Under concurrent topic churn for the
+// same owner, RadosGW's shared topic metadata can be briefly inconsistent, so
+// PutBucketNotificationConfiguration may return NoSuchKey, and CreateTopic/
+// DeleteTopic may return 5xx or ConcurrentModification, even for a valid request.
+func isTransientSNSError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isConcurrentModificationError(err) {
+		return true
+	}
+
+	// API errors, e.g. from PutBucketNotificationConfiguration.
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NoSuchKey", "InternalError", "ServiceUnavailable", "SlowDown", "RequestTimeout":
+			return true
+		}
+	}
+
+	// IAM/SNS client errors (topic create/delete): any 5xx, plus the
+	// transient codes seen under contention.
+	var iamErr *IAMError
+	if errors.As(err, &iamErr) {
+		if iamErr.StatusCode >= 500 {
+			return true
+		}
+		switch iamErr.Code {
+		case "NoSuchKey", "InternalError", "ServiceUnavailable", "SlowDown":
+			return true
+		}
+	}
+
+	return false
+}
+
+// retryOnTransientSNSError wraps an SNS topic or bucket-notification operation
+// with retry logic for transient errors (see isTransientSNSError).
+func retryOnTransientSNSError(ctx context.Context, operation string, fn func() error) error {
+	return retry.RetryContext(ctx, SNSTransientRetryTimeout, func() *retry.RetryError {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if isTransientSNSError(err) {
+			tflog.Debug(ctx, "Transient SNS error, retrying", map[string]any{
 				"operation": operation,
 				"error":     err.Error(),
 			})


### PR DESCRIPTION
RadosGW stores all of an owner's SNS topics in one shared metadata object. Under concurrent topic create/delete (heavy in the parallel acceptance suite; rarer but possible in production automation), Reef/Squid can briefly fail to resolve a just-created topic — PutBucketNotificationConfiguration returns 404 NoSuchKey and CreateTopic/DeleteTopic can return 5xx — even for valid requests. Tentacle is unaffected.

- Add retryOnTransientSNSError (typed: NoSuchKey/5xx/ConcurrentModification, 30s bound) and wrap PutBucketNotificationConfiguration (notification create/update/delete) and CreateTopic/DeleteTopic.
- Make the SNS topic test check helpers retry-until-consistent (they call the API directly, bypassing the provider retry).